### PR TITLE
Fix Railway deployment: use $PORT env var and add start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite build && vite preview"
   },
   "dependencies": {
     "lucide-react": "^0.577.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  preview: {
+    port: parseInt(process.env.PORT) || 4173,
+    host: '0.0.0.0',
+    allowedHosts: ['*'],
+  },
 })


### PR DESCRIPTION
- vite.config.js: configure preview server to bind 0.0.0.0 and read the PORT environment variable that Railway injects at runtime
- package.json: add a "start" script that builds then serves via vite preview, which Railway uses as the run command

https://claude.ai/code/session_01VhDv3Kf21xPrDPS9iif64e