### PR TITLE
Fix allowedHosts: use true instead of wildcard string

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,6 @@ export default defineConfig({
   preview: {
     port: parseInt(process.env.PORT) || 4173,
     host: '0.0.0.0',
-    allowedHosts: ['*'],
+    allowedHosts: true,
   },
 })


### PR DESCRIPTION
Vite does not support '*' as a wildcard in allowedHosts — setting it to true allows all hosts, which is required for Railway's dynamic *.up.railway.app domain.

https://claude.ai/code/session_01VhDv3Kf21xPrDPS9iif64e