### PR TITLE
Fix WFH calculation logic and add cross-measure interactions

### DIFF
--- a/src/constants/defaults.js
+++ b/src/constants/defaults.js
@@ -118,10 +118,10 @@ export const MEASURES = [
   {
     id: 'wfh',
     name: 'Work From Home',
-    description: 'Office workers work from home additional days, eliminating commute fuel use.',
+    description: 'Office workers work from home more days per week, eliminating commute fuel use. Baseline is 0.5 days/week.',
     hasSlider: true,
     sliderConfig: {
-      label: 'WFH days per week',
+      label: 'Total WFH days per week',
       min: 0.5,
       max: 5,
       step: 0.5,

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -16,12 +16,14 @@ import { getTotalCommuters } from '../constants/defaults';
 
 /**
  * 1. Work From Home
- * Extra WFH days reduce commute trips for office car commuters.
+ * Slider value is total WFH days per week.  We compare against the baseline
+ * WFH level (5 − baselineOfficeDays) to find the additional trip reduction.
  * A 15% rebound factor accounts for non-commute driving on WFH days.
  */
 export function calcWorkFromHome(params, sliderValue) {
-  const extraWFHDays = sliderValue;
-  const daysReduced = Math.min(extraWFHDays, params.baselineOfficeDays);
+  const wfhDays = sliderValue;
+  const baselineWfhDays = 5 - params.baselineOfficeDays;
+  const daysReduced = Math.max(0, wfhDays - baselineWfhDays);
   const tripReductionFraction = daysReduced / params.baselineOfficeDays;
 
   // Gross weekly fuel saved across all office car commuters
@@ -32,8 +34,8 @@ export function calcWorkFromHome(params, sliderValue) {
   const netDailyFuelSaved = (grossWeeklyFuelSaved * reboundFactor) / 7;
 
   // Economic cost scales non-linearly (quadratic-ish)
-  const annualEconomicImpact = 
-    (300 + 860 * daysReduced - 100 * Math.pow(daysReduced, 2) - 57 * Math.pow(daysReduced, 3)) 
+  const annualEconomicCost =
+    (300 + 860 * daysReduced - 100 * Math.pow(daysReduced, 2) - 57 * Math.pow(daysReduced, 3))
     * 1_000_000;
 
   return {
@@ -47,20 +49,23 @@ export function calcWorkFromHome(params, sliderValue) {
  * 2. Public Transport Mode Shift
  * Relative increase in PT mode share shifts commuters from car to PT.
  * Economic cost = extra commute time minus congestion reduction benefit.
+ * When WFH is active, mode shift only applies on days people commute.
  */
-export function calcPublicTransport(params, sliderValue) {
+export function calcPublicTransport(params, sliderValue, wfhDays = 0) {
   const ptIncreasePercent = sliderValue;
   const totalCommuters = getTotalCommuters(params);
+  const commutingFraction = (5 - wfhDays) / 5;
 
   const shiftedCommuters = totalCommuters * params.ptModeShare * (ptIncreasePercent / 100);
-  const dailyFuelSaved = shiftedCommuters * params.avgCommuteFuel;
+  const dailyFuelSaved = shiftedCommuters * params.avgCommuteFuel * commutingFraction;
 
   // PT adds ~20 min/day; 60% of that time is productive → 40% unproductive
   const extraHoursPerDay = shiftedCommuters * (20 / 60) * 0.40;
-  const annualTimeCost = extraHoursPerDay * 30 * 230; // $30/hr, 230 working days
+  const workingDaysPerYear = 230 * commutingFraction;
+  const annualTimeCost = extraHoursPerDay * 30 * workingDaysPerYear;
 
   // Congestion benefit: ~$15/day per car removed from the road
-  const congestionBenefit = shiftedCommuters * 15 * 230;
+  const congestionBenefit = shiftedCommuters * 15 * workingDaysPerYear;
 
   const annualEconomicCost = annualTimeCost - congestionBenefit;
 
@@ -75,20 +80,23 @@ export function calcPublicTransport(params, sliderValue) {
  * 3. Cycling & Walking Mode Shift
  * Similar to PT but with health/productivity benefits → net economic benefit.
  * Slight discount (0.85×) because active commuters tend to have shorter trips.
+ * When WFH is active, mode shift only applies on days people commute.
  */
-export function calcCycling(params, sliderValue) {
+export function calcCycling(params, sliderValue, wfhDays = 0) {
   const activeIncreasePercent = sliderValue;
   const totalCommuters = getTotalCommuters(params);
+  const commutingFraction = (5 - wfhDays) / 5;
 
   const shiftedCommuters =
     totalCommuters * params.activeModeShare * (activeIncreasePercent / 100);
-  const dailyFuelSaved = shiftedCommuters * params.avgCommuteFuel * 0.85;
+  const dailyFuelSaved = shiftedCommuters * params.avgCommuteFuel * 0.85 * commutingFraction;
 
   // Health benefit: 1.5 fewer sick days at $350/day value
   const healthBenefit = shiftedCommuters * 350 * 1.5;
-  // Household fuel savings: fuel cost avoided over 230 working days
+  // Household fuel savings: fuel cost avoided over actual commuting days
+  const workingDaysPerYear = 230 * commutingFraction;
   const fuelSavingsToHouseholds =
-    shiftedCommuters * params.avgCommuteFuel * 2.80 * 230;
+    shiftedCommuters * params.avgCommuteFuel * 2.80 * workingDaysPerYear;
   // Net benefit (negative cost)
   const annualEconomicCost = -(healthBenefit + fuelSavingsToHouseholds);
 
@@ -302,6 +310,11 @@ export function calculateAll(params, measureStates) {
   let totalAnnualCost = 0;
   let activeMeasureCount = 0;
 
+  // Determine effective WFH days for cross-measure interaction
+  const wfhState = measureStates.wfh;
+  const effectiveWfhDays =
+    wfhState && wfhState.enabled ? wfhState.value : 5 - params.baselineOfficeDays;
+
   // Calculate each active measure
   for (const [id, state] of Object.entries(measureStates)) {
     if (!state.enabled) {
@@ -312,7 +325,11 @@ export function calculateAll(params, measureStates) {
     const calcFn = CALC_MAP[id];
     if (!calcFn) continue;
 
-    const result = calcFn(params, state.value);
+    // Pass WFH days to commute-based mode shift measures
+    const needsWfhContext = id === 'publicTransport' || id === 'cycling';
+    const result = needsWfhContext
+      ? calcFn(params, state.value, effectiveWfhDays)
+      : calcFn(params, state.value);
     results[id] = { ...result, active: true };
     activeMeasureCount++;
 


### PR DESCRIPTION
## Summary
This PR fixes the Work From Home (WFH) calculation logic to properly interpret slider values as total WFH days (rather than additional days), and implements cross-measure interactions where public transport and cycling mode shifts account for reduced commuting days when WFH is active.

## Key Changes

- **WFH Calculation Fix**: Changed `calcWorkFromHome()` to interpret the slider value as total WFH days per week and compare against a baseline WFH level (5 − baselineOfficeDays) to calculate actual trip reduction. This fixes the logic from using `Math.min()` to `Math.max(0, wfhDays - baselineWfhDays)`.

- **Cross-Measure Interactions**: Updated `calcPublicTransport()` and `calcCycling()` to accept an optional `wfhDays` parameter and apply a `commutingFraction` factor to account for reduced commuting days when WFH is active. This ensures fuel savings, time costs, and benefits are scaled appropriately.

- **Centralized WFH Context**: Modified `calculateAll()` to determine effective WFH days once and pass them to commute-based mode shift measures, ensuring consistent interaction calculations across all measures.

- **Variable Naming & Documentation**: 
  - Renamed `annualEconomicImpact` to `annualEconomicCost` for consistency
  - Updated comments to clarify that slider values represent total WFH days and explain baseline comparisons
  - Enhanced measure descriptions to specify baseline WFH level (0.5 days/week)

## Implementation Details

The WFH baseline is calculated as `5 - params.baselineOfficeDays`, representing the default WFH days already in the baseline scenario. When users adjust the WFH slider, the actual trip reduction is the difference between the new total and this baseline, capped at zero.

For mode shift measures, the `commutingFraction = (5 - wfhDays) / 5` scales all commute-dependent calculations (fuel saved, time costs, congestion benefits) to reflect that fewer days are spent commuting when WFH increases.

https://claude.ai/code/session_018Hap5Gp59cJZos4v8YMMS3