### PR TITLE
Replace hardcoded fuel price with configurable parameter

### DIFF
--- a/src/constants/defaults.js
+++ b/src/constants/defaults.js
@@ -120,6 +120,12 @@ export const BASELINE_DEFAULTS = {
     label: 'Congestion benefit per car removed',
     tooltip: 'Estimated daily economic benefit per car removed from the road due to reduced congestion.',
   },
+  fuelPricePerLitre: {
+    value: 3.00,
+    unit: 'NZ$/litre',
+    label: 'Fuel price per litre',
+    tooltip: 'Average retail fuel price used to estimate household cost savings. Source: MBIE weekly fuel price monitoring.',
+  },
 };
 
 // Total commuters derived from office car commuters + PT + active mode shares

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -95,7 +95,7 @@ export function calcCycling(params, sliderValue, wfhDays = 0) {
   // Household fuel savings: fuel cost avoided over actual commuting days
   const workingDaysPerYear = 230 * commutingFraction;
   const fuelSavingsToHouseholds =
-    shiftedCommuters * params.avgCommuteFuel * 2.80 * workingDaysPerYear;
+    shiftedCommuters * params.avgCommuteFuel * params.fuelPricePerLitre * workingDaysPerYear;
   // Net benefit (negative cost)
   const annualEconomicCost = -(healthBenefit + fuelSavingsToHouseholds);
 
@@ -127,7 +127,7 @@ export function calcSpeedLimit(params, sliderValue) {
     ((totalAnnualVKT * affectedVKTShare) / avgOriginalSpeed) * timeIncrease;
   const personalTimeCost = extraHoursPerYear * 0.70 * 27;
   const commercialTimeCost = extraHoursPerYear * 0.30 * 40;
-  const fuelCostSaving = dailyFuelSaved * 365 * 2.80;
+  const fuelCostSaving = dailyFuelSaved * 365 * params.fuelPricePerLitre;
   const annualEconomicCost = personalTimeCost + commercialTimeCost - fuelCostSaving;
 
   return {
@@ -149,7 +149,7 @@ export function calcCarpooling(params, sliderValue) {
   const dailyFuelSaved = dailyCommuterFuel * vehicleReduction;
 
   // Net benefit from shared fuel costs (30% of fuel savings)
-  const annualEconomicCost = -(dailyFuelSaved * 365 * 2.80 * 0.3);
+  const annualEconomicCost = -(dailyFuelSaved * 365 * params.fuelPricePerLitre * 0.3);
 
   return {
     dailyFuelSaved,
@@ -219,8 +219,10 @@ export function calcEcoDriving(params, sliderValue) {
 
   const dailyFuelSaved = totalDailyFuel * (effectivenessPercent / 100) * 0.5;
 
-  // Campaign cost only
-  const annualEconomicCost = 8_000_000;
+  // Campaign cost minus household fuel cost savings
+  const campaignCost = 8_000_000;
+  const householdFuelSavings = dailyFuelSaved * 365 * params.fuelPricePerLitre;
+  const annualEconomicCost = campaignCost - householdFuelSavings;
 
   return {
     dailyFuelSaved,


### PR DESCRIPTION
## Summary
This PR replaces hardcoded fuel price values (2.80 NZ$/litre) with a configurable parameter throughout the calculations module, improving flexibility and maintainability of fuel cost estimates.

## Key Changes
- Added `fuelPricePerLitre` parameter to `BASELINE_DEFAULTS` with a default value of 3.00 NZ$/litre and documentation referencing MBIE weekly fuel price monitoring
- Updated `calcCycling()` to use `params.fuelPricePerLitre` instead of hardcoded 2.80
- Updated `calcSpeedLimit()` to use `params.fuelPricePerLitre` instead of hardcoded 2.80
- Updated `calcCarpooling()` to use `params.fuelPricePerLitre` instead of hardcoded 2.80
- Enhanced `calcEcoDriving()` to calculate household fuel cost savings and subtract from campaign cost, using `params.fuelPricePerLitre`

## Notable Implementation Details
- The fuel price parameter is now centrally managed and can be easily updated without modifying calculation logic
- `calcEcoDriving()` now properly accounts for household fuel savings as a benefit, offsetting the campaign cost rather than treating it as a pure expense
- All fuel cost calculations now consistently reference the same configurable parameter

https://claude.ai/code/session_01Enyjgys7fvABEe6koDZKT6