### PR TITLE
Fix og:image URLs to use Railway deployment domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,14 +11,14 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Fuel Reserves Estimator" />
     <meta property="og:description" content="An interactive tool for modelling demand-reduction measures and their impact on New Zealand's fuel supply reserves." />
-    <meta property="og:image" content="https://pjayathissa.github.io/fuel_supply_planning/og-preview.png" />
-    <meta property="og:url" content="https://pjayathissa.github.io/fuel_supply_planning/" />
+    <meta property="og:image" content="https://fuelsupplyplanning.up.railway.app/og-preview.png" />
+    <meta property="og:url" content="https://fuelsupplyplanning.up.railway.app/" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Fuel Reserves Estimator" />
     <meta name="twitter:description" content="An interactive tool for modelling demand-reduction measures and their impact on New Zealand's fuel supply reserves." />
-    <meta name="twitter:image" content="https://pjayathissa.github.io/fuel_supply_planning/og-preview.png" />
+    <meta name="twitter:image" content="https://fuelsupplyplanning.up.railway.app/og-preview.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
The OG image and URL meta tags were pointing to github.io but the site is deployed at fuelsupplyplanning.up.railway.app.

https://claude.ai/code/session_01R8qVpBKFEsK2u8Yr2Ybc7w