### PR TITLE
feat: auto-fetch MBIE fuel reserves data on app load

### DIFF
--- a/.github/workflows/update-fuel-stocks.yml
+++ b/.github/workflows/update-fuel-stocks.yml
@@ -1,0 +1,40 @@
+name: Update MBIE Fuel Stocks Data
+
+on:
+  schedule:
+    # MBIE publishes updates Monday and Wednesday afternoons (NZ time = UTC+12/13).
+    # Run at 06:00 UTC (6-7 PM NZT) on Mon & Wed to catch the afternoon updates.
+    - cron: '0 6 * * 1,3'
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  scrape-and-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run MBIE scraper
+        run: node scripts/scrape-mbie-fuel-stocks.mjs
+
+      - name: Check for changes
+        id: check
+        run: |
+          git diff --quiet public/data/fuel-stocks.json && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push updated data
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/data/fuel-stocks.json
+          git commit -m "chore: update MBIE fuel stocks data ($(date -u +%Y-%m-%d))"
+          git push

--- a/public/data/fuel-stocks.json
+++ b/public/data/fuel-stocks.json
@@ -1,0 +1,26 @@
+{
+  "lastUpdated": "2026-03-18",
+  "source": "MBIE Fuel Stocks Update",
+  "sourceUrl": "https://www.mbie.govt.nz/about/news/fuel-stocks-update",
+  "note": "Data as at 11:59 PM Wednesday 18 March 2026. Updated automatically via GitHub Actions.",
+  "dailyDemand": {
+    "petrol": 8.1,
+    "diesel": 10.7,
+    "jetFuel": 4.8,
+    "unit": "million litres/day"
+  },
+  "daysOfCover": {
+    "petrol": {
+      "inCountry": 28,
+      "total": 49.9
+    },
+    "diesel": {
+      "inCountry": 21,
+      "total": 45.5
+    },
+    "jetFuel": {
+      "inCountry": 24,
+      "total": 44.7
+    }
+  }
+}

--- a/scripts/scrape-mbie-fuel-stocks.mjs
+++ b/scripts/scrape-mbie-fuel-stocks.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Scrapes MBIE's fuel stocks update page for the latest NZ fuel reserve data.
+ *
+ * MBIE publishes updates every Monday and Wednesday afternoon at:
+ * https://www.mbie.govt.nz/about/news/fuel-stocks-update
+ *
+ * Outputs: public/data/fuel-stocks.json
+ */
+
+import { writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT_PATH = join(__dirname, '..', 'public', 'data', 'fuel-stocks.json');
+
+const MBIE_URL =
+  'https://www.mbie.govt.nz/about/news/fuel-stocks-update';
+
+// Fallback: the more detailed page that MBIE maintains during supply disruptions
+const MBIE_FALLBACK_URL =
+  'https://www.mbie.govt.nz/building-and-energy/energy-and-natural-resources/energy-generation-and-markets/liquid-fuel-market/fuel-supply-disruption-response/middle-east-conflict-and-new-zealands-fuel-stocks';
+
+/**
+ * Fetch a URL with browser-like headers to avoid 403 blocks.
+ */
+async function fetchPage(url) {
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+      Accept:
+        'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'Accept-Language': 'en-NZ,en;q=0.9',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} fetching ${url}`);
+  }
+  return res.text();
+}
+
+/**
+ * Parse a number from text, handling commas and whitespace.
+ */
+function parseNum(text) {
+  if (!text) return null;
+  const cleaned = text.replace(/[,\s]/g, '');
+  const n = parseFloat(cleaned);
+  return Number.isNaN(n) ? null : n;
+}
+
+/**
+ * Extract fuel stock data from the HTML.
+ *
+ * MBIE pages typically contain tables with columns like:
+ *   Fuel type | In-country (days) | On water (days) | Total (days)
+ *
+ * We also look for the "as at" date and daily demand figures.
+ */
+function extractData(html) {
+  const data = {
+    lastUpdated: null,
+    source: 'MBIE Fuel Stocks Update',
+    sourceUrl: MBIE_URL,
+    note: '',
+    dailyDemand: {
+      petrol: null,
+      diesel: null,
+      jetFuel: null,
+      unit: 'million litres/day',
+    },
+    daysOfCover: {
+      petrol: { inCountry: null, total: null },
+      diesel: { inCountry: null, total: null },
+      jetFuel: { inCountry: null, total: null },
+    },
+  };
+
+  // --- Extract "as at" date ---
+  // Look for patterns like "as at 11:59PM on Wednesday 18 March" or "as at ... March 2026"
+  const dateMatch = html.match(
+    /as\s+at[^<]*?(\d{1,2})\s+(January|February|March|April|May|June|July|August|September|October|November|December)\s*(\d{4})?/i
+  );
+  if (dateMatch) {
+    const day = dateMatch[1];
+    const monthName = dateMatch[2];
+    const year = dateMatch[3] || new Date().getFullYear().toString();
+    const monthIndex = new Date(`${monthName} 1, 2000`).getMonth();
+    const d = new Date(parseInt(year), monthIndex, parseInt(day));
+    data.lastUpdated = d.toISOString().split('T')[0];
+  }
+
+  // --- Extract table data ---
+  // Find all HTML tables and look for fuel stock data
+  const tableRegex = /<table[^>]*>([\s\S]*?)<\/table>/gi;
+  let tableMatch;
+
+  while ((tableMatch = tableRegex.exec(html)) !== null) {
+    const tableHtml = tableMatch[1];
+
+    // Check if this table contains fuel stock info
+    if (!/petrol|diesel|jet\s*fuel/i.test(tableHtml)) continue;
+
+    // Extract rows
+    const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+    let rowMatch;
+    const rows = [];
+
+    while ((rowMatch = rowRegex.exec(tableHtml)) !== null) {
+      const cellRegex = /<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/gi;
+      let cellMatch;
+      const cells = [];
+      while ((cellMatch = cellRegex.exec(rowMatch[1])) !== null) {
+        // Strip HTML tags from cell content
+        cells.push(cellMatch[1].replace(/<[^>]+>/g, '').trim());
+      }
+      if (cells.length > 0) rows.push(cells);
+    }
+
+    if (rows.length < 2) continue;
+
+    // Identify column indices from header row
+    const header = rows[0].map((h) => h.toLowerCase());
+    let inCountryCol = header.findIndex(
+      (h) => /in.?country/i.test(h) || /onshore/i.test(h)
+    );
+    let totalCol = header.findIndex(
+      (h) => /total/i.test(h) || /combined/i.test(h)
+    );
+    let onWaterCol = header.findIndex((h) => /on.?water/i.test(h));
+
+    // If we can't find labelled columns, try positional (fuel, in-country, on-water, total)
+    if (inCountryCol === -1 && rows[0].length >= 3) inCountryCol = 1;
+    if (totalCol === -1 && rows[0].length >= 4) totalCol = rows[0].length - 1;
+
+    // Parse data rows
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      const label = row[0]?.toLowerCase() || '';
+
+      let fuelKey = null;
+      if (/petrol|gasoline/i.test(label)) fuelKey = 'petrol';
+      else if (/diesel/i.test(label)) fuelKey = 'diesel';
+      else if (/jet/i.test(label)) fuelKey = 'jetFuel';
+
+      if (!fuelKey) continue;
+
+      if (inCountryCol >= 0 && row[inCountryCol]) {
+        data.daysOfCover[fuelKey].inCountry = parseNum(row[inCountryCol]);
+      }
+      if (totalCol >= 0 && row[totalCol]) {
+        data.daysOfCover[fuelKey].total = parseNum(row[totalCol]);
+      }
+      // If no total but we have in-country and on-water, compute total
+      if (
+        data.daysOfCover[fuelKey].total === null &&
+        onWaterCol >= 0 &&
+        row[onWaterCol]
+      ) {
+        const onWater = parseNum(row[onWaterCol]);
+        if (onWater !== null && data.daysOfCover[fuelKey].inCountry !== null) {
+          data.daysOfCover[fuelKey].total =
+            data.daysOfCover[fuelKey].inCountry + onWater;
+        }
+      }
+    }
+  }
+
+  // --- Extract daily demand ---
+  // Look for patterns like "Petrol 8.1" or "Petrol: 8.1 million litres"
+  const demandSection = html.match(
+    /average\s+daily\s+demand[\s\S]{0,500}/i
+  );
+  if (demandSection) {
+    const text = demandSection[0];
+    const petrolDemand = text.match(/petrol[:\s]+(\d+\.?\d*)/i);
+    const dieselDemand = text.match(/diesel[:\s]+(\d+\.?\d*)/i);
+    const jetDemand = text.match(/jet\s*fuel[:\s]+(\d+\.?\d*)/i);
+
+    if (petrolDemand) data.dailyDemand.petrol = parseFloat(petrolDemand[1]);
+    if (dieselDemand) data.dailyDemand.diesel = parseFloat(dieselDemand[1]);
+    if (jetDemand) data.dailyDemand.jetFuel = parseFloat(jetDemand[1]);
+  }
+
+  // Build note
+  data.note = data.lastUpdated
+    ? `MBIE data as at ${data.lastUpdated}. Updated automatically via GitHub Actions.`
+    : 'Auto-scraped from MBIE. Date could not be determined.';
+
+  return data;
+}
+
+/**
+ * Validate that we got meaningful data.
+ */
+function isValid(data) {
+  const cover = data.daysOfCover;
+  // At minimum we need petrol or diesel total days
+  return (
+    (cover.petrol.total !== null && cover.petrol.total > 0) ||
+    (cover.diesel.total !== null && cover.diesel.total > 0)
+  );
+}
+
+async function main() {
+  console.log('Fetching MBIE fuel stocks data...');
+
+  let data = null;
+
+  // Try primary URL first, then fallback
+  for (const url of [MBIE_URL, MBIE_FALLBACK_URL]) {
+    try {
+      console.log(`  Trying: ${url}`);
+      const html = await fetchPage(url);
+      const extracted = extractData(html);
+      extracted.sourceUrl = url;
+
+      if (isValid(extracted)) {
+        data = extracted;
+        console.log('  Success! Data extracted.');
+        break;
+      } else {
+        console.log('  Page fetched but no valid fuel stock data found.');
+      }
+    } catch (err) {
+      console.log(`  Failed: ${err.message}`);
+    }
+  }
+
+  if (!data) {
+    console.error(
+      '\nERROR: Could not extract fuel stock data from any MBIE page.'
+    );
+    console.error(
+      'The page structure may have changed. Manual update of public/data/fuel-stocks.json required.'
+    );
+    process.exit(1);
+  }
+
+  // Write output
+  const json = JSON.stringify(data, null, 2) + '\n';
+  writeFileSync(OUTPUT_PATH, json, 'utf-8');
+  console.log(`\nWrote ${OUTPUT_PATH}`);
+  console.log(`  Last updated: ${data.lastUpdated}`);
+  console.log(
+    `  Petrol: ${data.daysOfCover.petrol.inCountry}d in-country, ${data.daysOfCover.petrol.total}d total`
+  );
+  console.log(
+    `  Diesel: ${data.daysOfCover.diesel.inCountry}d in-country, ${data.daysOfCover.diesel.total}d total`
+  );
+  console.log(
+    `  Jet fuel: ${data.daysOfCover.jetFuel.inCountry}d in-country, ${data.daysOfCover.jetFuel.total}d total`
+  );
+}
+
+main();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,9 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import { BookOpen, BarChart3 } from 'lucide-react';
 import { BASELINE_DEFAULTS, MEASURES } from './constants/defaults';
 import { calculateAll } from './utils/calculations';
 import { decodeScenario } from './utils/sharing';
+import { fetchFuelStocks, mapStocksToParams } from './utils/fetchReserves';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import BaselinePanel from './components/BaselinePanel';
@@ -60,6 +61,27 @@ export default function App() {
   const [methodologyOpen, setMethodologyOpen] = useState(false);
   const [wfhAssumptionsOpen, setWfhAssumptionsOpen] = useState(false);
   const [showChart, setShowChart] = useState(false);
+  const [dataInfo, setDataInfo] = useState(null); // { lastUpdated, source, sourceUrl }
+
+  // Fetch latest MBIE fuel stock data on mount
+  useEffect(() => {
+    fetchFuelStocks().then((stockData) => {
+      if (!stockData) return;
+
+      setDataInfo({
+        lastUpdated: stockData.lastUpdated,
+        source: stockData.source,
+        sourceUrl: stockData.sourceUrl,
+      });
+
+      // Only auto-apply if user hasn't loaded a shared scenario
+      const hasScenario = !!decodeScenario(window.location.search);
+      if (!hasScenario) {
+        const overrides = mapStocksToParams(stockData);
+        setParams((prev) => ({ ...prev, ...overrides }));
+      }
+    });
+  }, []);
 
   // Recalculate results whenever params or measure states change
   const results = useMemo(
@@ -126,6 +148,7 @@ export default function App() {
             baselineParams={params}
             showChart={showChart}
             onToggleChart={() => setShowChart((v) => !v)}
+            dataInfo={dataInfo}
           />
 
           {/* Action buttons — desktop only */}

--- a/src/components/ResultsDashboard.jsx
+++ b/src/components/ResultsDashboard.jsx
@@ -32,7 +32,7 @@ function getDollarUnit(value) {
 /**
  * Main results display — always visible, updates dynamically.
  */
-export default function ResultsDashboard({ results, baselineParams, showChart, onToggleChart }) {
+export default function ResultsDashboard({ results, baselineParams, showChart, onToggleChart, dataInfo }) {
   if (!results) return null;
 
   const {
@@ -52,6 +52,13 @@ export default function ResultsDashboard({ results, baselineParams, showChart, o
   return (
     <div className="results-dashboard">
       <h2 className="section-title mobile-hidden">Impact Summary</h2>
+
+      {dataInfo?.lastUpdated && (
+        <div className="data-freshness">
+          Reserves data: <a href={dataInfo.sourceUrl} target="_blank" rel="noopener noreferrer">{dataInfo.source}</a>
+          {' '}— {dataInfo.lastUpdated}
+        </div>
+      )}
 
       {/* Fuel gauge visualisation */}
       <FuelGauge

--- a/src/index.css
+++ b/src/index.css
@@ -153,6 +153,24 @@ h1, h2, h3, h4 {
   border-bottom: 2px solid var(--grey-200);
 }
 
+/* ─── Data freshness indicator ──────────────────────────────────────────── */
+
+.data-freshness {
+  font-size: 0.8rem;
+  color: var(--grey-500);
+  margin-bottom: var(--space-md);
+  margin-top: calc(-1 * var(--space-sm));
+}
+
+.data-freshness a {
+  color: var(--teal);
+  text-decoration: none;
+}
+
+.data-freshness a:hover {
+  text-decoration: underline;
+}
+
 /* ─── Baseline panel ────────────────────────────────────────────────────── */
 
 .baseline-panel {

--- a/src/utils/fetchReserves.js
+++ b/src/utils/fetchReserves.js
@@ -1,0 +1,110 @@
+/**
+ * Fetches the latest MBIE fuel stock data from the static JSON file.
+ *
+ * The JSON is maintained by a GitHub Action that scrapes MBIE every Mon/Wed.
+ * Falls back gracefully — returns null if the fetch fails so the app
+ * continues with its hardcoded defaults.
+ */
+
+const DATA_URL = `${import.meta.env.BASE_URL}data/fuel-stocks.json`;
+
+/**
+ * @typedef {Object} FuelStocksData
+ * @property {string} lastUpdated - ISO date string (e.g. "2026-03-18")
+ * @property {string} source
+ * @property {string} sourceUrl
+ * @property {Object} dailyDemand
+ * @property {Object} daysOfCover
+ */
+
+/**
+ * Fetch the latest fuel stocks JSON.
+ * @returns {Promise<FuelStocksData|null>}
+ */
+export async function fetchFuelStocks() {
+  try {
+    // Cache-bust to ensure we always get the latest committed version
+    const url = `${DATA_URL}?t=${Date.now()}`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+
+    const data = await res.json();
+
+    // Basic validation
+    if (!data?.daysOfCover?.petrol && !data?.daysOfCover?.diesel) {
+      return null;
+    }
+
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Map fetched MBIE data to the app's baseline parameter overrides.
+ * Only overrides values that are present and valid in the fetched data.
+ *
+ * @param {FuelStocksData} stockData
+ * @returns {Object} param key-value pairs to merge into app params
+ */
+export function mapStocksToParams(stockData) {
+  const overrides = {};
+
+  // Onshore reserve days — use weighted average of petrol + diesel in-country days
+  const petrolInCountry = stockData.daysOfCover?.petrol?.inCountry;
+  const dieselInCountry = stockData.daysOfCover?.diesel?.inCountry;
+
+  if (petrolInCountry != null && dieselInCountry != null) {
+    // Weight by daily demand if available, otherwise simple average
+    const petrolDemand = stockData.dailyDemand?.petrol;
+    const dieselDemand = stockData.dailyDemand?.diesel;
+
+    if (petrolDemand && dieselDemand) {
+      overrides.onshoreReserveDays = Math.round(
+        (petrolInCountry * petrolDemand + dieselInCountry * dieselDemand) /
+          (petrolDemand + dieselDemand)
+      );
+    } else {
+      overrides.onshoreReserveDays = Math.round(
+        (petrolInCountry + dieselInCountry) / 2
+      );
+    }
+  } else if (petrolInCountry != null) {
+    overrides.onshoreReserveDays = Math.round(petrolInCountry);
+  } else if (dieselInCountry != null) {
+    overrides.onshoreReserveDays = Math.round(dieselInCountry);
+  }
+
+  // Total reserve days — weighted average of petrol + diesel total days
+  const petrolTotal = stockData.daysOfCover?.petrol?.total;
+  const dieselTotal = stockData.daysOfCover?.diesel?.total;
+
+  if (petrolTotal != null && dieselTotal != null) {
+    const petrolDemand = stockData.dailyDemand?.petrol;
+    const dieselDemand = stockData.dailyDemand?.diesel;
+
+    if (petrolDemand && dieselDemand) {
+      overrides.totalReserveDays = Math.round(
+        (petrolTotal * petrolDemand + dieselTotal * dieselDemand) /
+          (petrolDemand + dieselDemand)
+      );
+    } else {
+      overrides.totalReserveDays = Math.round((petrolTotal + dieselTotal) / 2);
+    }
+  } else if (petrolTotal != null) {
+    overrides.totalReserveDays = Math.round(petrolTotal);
+  } else if (dieselTotal != null) {
+    overrides.totalReserveDays = Math.round(dieselTotal);
+  }
+
+  // Daily consumption overrides
+  if (stockData.dailyDemand?.petrol != null) {
+    overrides.dailyPetrolConsumption = stockData.dailyDemand.petrol;
+  }
+  if (stockData.dailyDemand?.diesel != null) {
+    overrides.dailyDieselConsumption = stockData.dailyDemand.diesel;
+  }
+
+  return overrides;
+}


### PR DESCRIPTION
## Summary\n\n- **GitHub Action scraper** (`scripts/scrape-mbie-fuel-stocks.mjs`) runs every Monday & Wednesday at 6 PM NZT to fetch the latest fuel stock data from [MBIE's fuel stocks update page](https://www.mbie.govt.nz/about/news/fuel-stocks-update) and commits it as `public/data/fuel-stocks.json`\n- **Client-side fetch** (`src/utils/fetchReserves.js`) loads this JSON on app startup and auto-updates baseline parameters (onshore reserve days, total reserve days, daily petrol/diesel consumption) with the latest MBIE figures\n- **Data freshness indicator** shown in the Results Dashboard linking to the MBIE source with the date of last update\n- Falls back gracefully to hardcoded defaults if the fetch fails or data is unavailable\n- Shared URL scenarios are respected — live data won't override user-shared parameter overrides\n\n## How it works\n\n1. MBIE publishes fuel stock updates every Mon/Wed afternoon (NZT)\n2. GitHub Action triggers at 6 PM NZT, scrapes the page, parses the HTML tables for days-of-cover and daily demand figures\n3. If data changed, it commits the updated `fuel-stocks.json`\n4. When a user loads the app, it fetches this static JSON and maps the MBIE data to baseline params\n5. The workflow can also be triggered manually via `workflow_dispatch`\n\n## Files changed\n\n| File | Description |\n|------|-------------|\n| `public/data/fuel-stocks.json` | Static JSON seeded with MBIE data as at 18 March 2026 |\n| `scripts/scrape-mbie-fuel-stocks.mjs` | Node.js scraper for MBIE fuel stocks page |\n| `.github/workflows/update-fuel-stocks.yml` | Scheduled GitHub Action (Mon/Wed) |\n| `src/utils/fetchReserves.js` | Client-side fetch + param mapping utility |\n| `src/App.jsx` | Added useEffect to fetch data on mount |\n| `src/components/ResultsDashboard.jsx` | Added data freshness indicator |\n| `src/index.css` | Styles for freshness indicator |\n\n## Test plan\n\n- [ ] Verify app builds successfully (`npm run build`)\n- [ ] Verify app loads and displays the MBIE data freshness indicator in the results dashboard\n- [ ] Verify baseline params (onshore days, total days) update from the JSON on load\n- [ ] Verify shared URL scenarios still override baseline params correctly\n- [ ] Manually trigger the GitHub Action (`workflow_dispatch`) and confirm it scrapes and commits updated data\n- [ ] Verify fallback: if `fuel-stocks.json` is removed, app still works with hardcoded defaults\n\nhttps://claude.ai/code/session_01XgANMQw6NnzBtgjuHTFAMZ